### PR TITLE
Fix markup for mobile menu button

### DIFF
--- a/Hero.html
+++ b/Hero.html
@@ -6,7 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js"></script>
@@ -241,11 +241,11 @@
                     </a>
                     <button id="mobile-menu-button" class="md:hidden ml-4 p-2 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500" aria-expanded="false" aria-controls="mobile-menu">
                         <span class="sr-only">Open main menu</span>
-                        <div class="hamburger-icon space-y-1.5">
+                        <span class="hamburger-icon space-y-1.5 inline-block">
                             <span class="line line1 block w-6 h-0.5 bg-gray-700"></span>
                             <span class="line line2 block w-6 h-0.5 bg-gray-700"></span>
                             <span class="line line3 block w-6 h-0.5 bg-gray-700"></span>
-                        </div>
+                        </span>
                     </button>
                 </div>
             </div>
@@ -292,7 +292,7 @@
                 <div class="mt-12 relative sm:max-w-lg sm:mx-auto lg:mt-0 lg:max-w-none lg:mx-0 lg:col-span-5 lg:flex lg:items-center">
                     <div class="relative mx-auto w-full rounded-lg shadow-lg floating bg-white p-6">
                         <div class="flex items-center mb-5">
-                            <img class="h-16 w-16 rounded-lg object-cover" src="https://images.unsplash.com/photo-1605236453806-6ff36851218e?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=764&q=80" alt="Mockup of Limina app showing iPhone 16 Pro price tracking" loading="lazy"> <div class="ml-4">
+                            <img class="h-16 w-16 rounded-lg object-cover" src="https://images.unsplash.com/photo-1605236453806-6ff36851218e?ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&amp;auto=format&amp;fit=crop&amp;w=764&amp;q=80" alt="Mockup of Limina app showing iPhone 16 Pro price tracking" loading="lazy"> <div class="ml-4">
                                 <h3 class="font-medium text-gray-800 text-lg">iPhone 16 Pro</h3>
                                 <p class="text-sm text-gray-500">Current price: <span class="line-through">£799</span> <span class="font-bold text-green-600">£749</span></p>
                             </div>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script>
         tailwind.config = {
@@ -579,11 +579,11 @@
                     
                     <button id="mobile-menu-button" class="md:hidden ml-4 p-2 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary transition-colors">
                         <span class="sr-only">Open main menu</span>
-                        <div class="hamburger-icon space-y-1.5">
+                        <span class="hamburger-icon space-y-1.5 inline-block">
                             <span class="hamburger-line line1 block w-6 h-0.5 bg-gray-700"></span>
                             <span class="hamburger-line line2 block w-6 h-0.5 bg-gray-700"></span>
                             <span class="hamburger-line line3 block w-6 h-0.5 bg-gray-700"></span>
-                        </div>
+                        </span>
                     </button>
                 </div>
             </div>
@@ -653,7 +653,7 @@
                     <div class="hero-card floating rounded-3xl p-8 w-full max-w-md scroll-animate">
                         <div class="flex items-center justify-between mb-6">
                             <div class="flex items-center">
-                                <img class="h-16 w-16 rounded-2xl object-cover" src="https://images.unsplash.com/photo-1605236453806-6ff36851218e?ixlib=rb-4.0.3&auto=format&fit=crop&w=764&q=80" alt="iPhone 16 Pro" loading="lazy">
+                                <img class="h-16 w-16 rounded-2xl object-cover" src="https://images.unsplash.com/photo-1605236453806-6ff36851218e?ixlib=rb-4.0.3&amp;auto=format&amp;fit=crop&amp;w=764&amp;q=80" alt="iPhone 16 Pro" loading="lazy">
                                 <div class="ml-4">
                                     <h3 class="font-semibold text-gray-800 text-lg">iPhone 16 Pro</h3>
                                     <p class="text-gray-600">Current: <span class="text-xl font-bold">£999</span></p>


### PR DESCRIPTION
## Summary
- encode ampersands in Google Fonts and image URLs
- replace invalid `<div>` inside `<button>` with `<span>` for hamburger menu

## Testing
- `tidy -errors index.html`
- `tidy -errors Hero.html`


------
https://chatgpt.com/codex/tasks/task_e_6840205a7c28832bb780dd137971d5dd