### PR TITLE
Add HTML lint workflow

### DIFF
--- a/.github/workflows/html-lint.yml
+++ b/.github/workflows/html-lint.yml
@@ -1,0 +1,20 @@
+name: HTML Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  html-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install htmlhint
+        run: npm install -g htmlhint
+      - name: Run htmlhint
+        run: htmlhint '**/*.html'

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,11 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": false,
+  "tag-pair": true,
+  "spec-char-escape": true,
+  "id-unique": true,
+  "head-script-disabled": false,
+  "style-disabled": false
+}


### PR DESCRIPTION
## Summary
- add `.htmlhintrc` with basic HTMLHint rules
- set up GitHub Actions workflow that runs `htmlhint` on HTML files

## Testing
- `npx htmlhint '**/*.html'` *(fails: found errors)*

------
https://chatgpt.com/codex/tasks/task_e_684022acb228832b8c76a40e4ce0fe13